### PR TITLE
SSH Security improvements

### DIFF
--- a/tasks/hardening_debian.yml
+++ b/tasks/hardening_debian.yml
@@ -161,9 +161,9 @@
     regexp='^#?{{ item.key }}'
     line='{{ item.key }} {{ item.value }}'
   with_items:
-    - { key: 'Ciphers', value: 'aes256-ctr,aes192-ctr,aes128-ctr'}
-    - { key: 'MACs', value: 'hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'}
-    - { key: 'KexAlgorithms', value: 'diffie-hellman-group-exchange-sha256'}
+    - { key: 'Ciphers', value: 'chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr'}
+    - { key: 'MACs', value: 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160'}
+    - { key: 'KexAlgorithms', value: 'curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256'}
   when: ssh_strong_ciphers
   notify: restart ssh
 


### PR DESCRIPTION
- Ciphers: Added Chacha20-Poly1305 (faster than AES in GCM mode but as secure as it) + AES in    GCM mode (more secure than CBC+CTR)
- MACs: Added SHA512+SHA256 in Encrypt-then-Mac-Mode
- Key Exchange Algorithms: added Curve25519 - proven to be secure and even faster than DH
